### PR TITLE
Fix CustomTkinter scrollbar callbacks in GUI

### DIFF
--- a/DidMySettingsChange.py
+++ b/DidMySettingsChange.py
@@ -386,7 +386,19 @@ def run_gui():
 
     scrollbar = ctk.CTkScrollbar(output_frame, command=output_text.yview)
     scrollbar.place(relx=1, rely=0, relheight=1, anchor="ne")
-    output_text.configure(yscrollcommand=scrollbar.set)
+
+    def _sync_scrollbar(*args: str) -> None:
+        if len(args) != 2:
+            return
+
+        try:
+            start, end = (float(value) for value in args)
+        except (TypeError, ValueError):
+            return
+
+        scrollbar.set(start, end)
+
+    output_text.configure(yscrollcommand=_sync_scrollbar)
 
     def append_output(message: str) -> None:
         output_text.configure(state="normal")


### PR DESCRIPTION
## Summary
- wrap the CustomTkinter textbox yscroll callback so non-numeric arguments are ignored
- prevent ValueError crashes when the GUI appends output and scrolls to the end

## Testing
- python -m compileall DidMySettingsChange.py

------
https://chatgpt.com/codex/tasks/task_e_68dee760104c8331839b6da559a97e41