### PR TITLE
Handle customtkinter text state errors

### DIFF
--- a/DidMySettingsChange.py
+++ b/DidMySettingsChange.py
@@ -29,13 +29,13 @@ def emit_message(message: str, output_widget: Optional[tk.Text]) -> None:
     if output_widget:
         try:
             previous_state = output_widget.cget("state")  # type: ignore[call-arg]
-        except (tk.TclError, AttributeError):
+        except (tk.TclError, AttributeError, ValueError):
             previous_state = "normal"
 
         if previous_state == "disabled":
             try:
                 output_widget.configure(state="normal")  # type: ignore[call-arg]
-            except (tk.TclError, AttributeError):
+            except (tk.TclError, AttributeError, ValueError):
                 previous_state = "normal"
 
         output_widget.insert(tk.END, message + "\n")
@@ -44,7 +44,7 @@ def emit_message(message: str, output_widget: Optional[tk.Text]) -> None:
         if previous_state == "disabled":
             try:
                 output_widget.configure(state="disabled")  # type: ignore[call-arg]
-            except (tk.TclError, AttributeError):
+            except (tk.TclError, AttributeError, ValueError):
                 pass
     else:
         print(message)


### PR DESCRIPTION
## Summary
- update emit_message to treat CustomTkinter ValueError responses the same as Tkinter errors
- ensure state toggling falls back to normal when CustomTkinter does not expose a state attribute

## Testing
- not run (GUI change)

------
https://chatgpt.com/codex/tasks/task_e_68dee873c258833197d5e6e647283b00