### PR TITLE
Display baseline snapshot in UI when capturing settings

### DIFF
--- a/DidMySettingsChange.py
+++ b/DidMySettingsChange.py
@@ -219,12 +219,27 @@ def monitor_settings(mode, output_widget=None):
 
         _, current_settings, warnings = check_settings(config, {})
         save_database(current_settings)
+
+        if current_settings:
+            emit_message("Captured baseline values:", output_widget)
+            for setting_name in sorted(current_settings):
+                emit_message(
+                    f" - {setting_name}: {current_settings[setting_name]}",
+                    output_widget,
+                )
+        else:
+            emit_message(
+                "Warning: No settings were captured. Verify the configuration paths are correct.",
+                output_widget,
+            )
+
+        for warning in warnings:
+            emit_message(warning, output_widget)
+
         emit_message(
             "Initial setup complete. Run the monitor again to compare against the saved baseline.",
             output_widget,
         )
-        for warning in warnings:
-            emit_message(warning, output_widget)
         return
 
     changes, current_settings, warnings = check_settings(config, database)


### PR DESCRIPTION
## Summary
- display the captured baseline settings in the UI when the database is first created
- warn when no settings are captured and continue surfacing PowerShell warnings before completion

## Testing
- python -m compileall DidMySettingsChange.py

------
https://chatgpt.com/codex/tasks/task_e_68df1c8f788c8331bd8960f17f49b320